### PR TITLE
Issue 74 - Fix CSV format for Mac Excel

### DIFF
--- a/route/result/download.js
+++ b/route/result/download.js
@@ -52,7 +52,7 @@ function route (app) {
                 JSON.stringify(msg.code),
                 JSON.stringify(msg.message),
                 JSON.stringify(msg.type)
-            ].join(', '));
+            ].join(','));
         });
         res.attachment(getDownloadFileName(task, result, 'csv'));
         res.send(rows.join('\n'));


### PR DESCRIPTION
Removed the space that throws off Excel CSV import.
