### PR TITLE
Show first context and selector on results page

### DIFF
--- a/view/partial/result.html
+++ b/view/partial/result.html
@@ -82,7 +82,8 @@ along with pa11y-dashboard.  If not, see <http://www.gnu.org/licenses/>.
 				{{#mainResult.errors}}
 					<li>
 						<p class="crunch rule-name">{{code}} <span class="badge">{{count}}</span></p>
-						<p>{{message}}</p>
+						<p><em>First result:</em> {{message}}</p>
+						<p><em>Selector:</em> {{selector}}, <em>Context:</em> {{context}}</p>
 						{{#unless readonly}}
 							{{#if ../../isTaskPage}}
 								<form action="{{../../../task.hrefIgnore}}" method="post">
@@ -110,7 +111,8 @@ along with pa11y-dashboard.  If not, see <http://www.gnu.org/licenses/>.
 				{{#mainResult.warnings}}
 					<li>
 						<p class="crunch rule-name">{{code}} <span class="badge">{{count}}</span></p>
-						<p>{{message}}</p>
+						<p><em>First result:</em> {{message}}</p>
+						<p><em>Selector:</em> {{selector}}, <em>Context:</em> {{context}}</p>
 						{{#unless readonly}}
 							{{#if ../../isTaskPage}}
 								<form action="{{../../../task.hrefIgnore}}" method="post">
@@ -139,7 +141,8 @@ along with pa11y-dashboard.  If not, see <http://www.gnu.org/licenses/>.
 				{{#mainResult.notices}}
 					<li>
 						<p class="crunch rule-name">{{code}} <span class="badge">{{count}}</span></p>
-						<p>{{message}}</p>
+						<p><em>First result:</em> {{message}}</p>
+						<p><em>Selector:</em> {{selector}}, <em>Context:</em> {{context}}</p>
 						{{#unless readonly}}
 							{{#if ../../isTaskPage}}
 								<form action="{{../../../task.hrefIgnore}}" method="post">


### PR DESCRIPTION
The message shown is sometimes specific to the first result (e.g. for contrast it gives a background colour to use instead), so point out it's data from the first result for that ID, and show its context and selector too.

It'd be good if it could show all context/selector/messages, but this seemed an easier start to begin with :)
