### PR TITLE
Release 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@
 language: node_js
 matrix:
   include:
-    - node_js: '0.10'
-    - node_js: '0.12'
     - node_js: '4'
     - node_js: '5'
     - node_js: '6'

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,19 @@
+
+Migration Guide
+===============
+
+Pa11y Dashboard's API changes between major versions. This is a guide to help you make the switch when this happens.
+
+
+Table Of Contents
+-----------------
+
+- [Migrating from 1.0 to 2.0](#migrating-from-10-to-20)
+
+
+Migrating from 1.0 to 2.0
+-------------------------
+
+### Node.js Support
+
+The only breaking change in Pa11y Dashboard 2.0 is that Node.js 0.10 and 0.12 are no longer supported. We'll be using newer ES6 features in upcoming releases which will not work in these older Node.js versions.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,21 @@ Useful Resources
 * [Setting up An Accessibility Dashboard from Scratch with Pa11y on DigitialOcean][resource-una-k]
 
 
+Support and Migration
+---------------------
+
+Pa11y Dashboard major versions are normally supported for 6 months after their last minor release. This means that patch-level changes will be added and bugs will be fixed. The table below outlines the end-of-support dates for major versions, and the last minor release for that version.
+
+We also maintain a [migration guide](MIGRATION.md) to help you migrate.
+
+| :grey_question: | Major Version | Last Minor Release | Node.js Versions | Support End Date |
+| :-------------- | :------------ | :----------------- | :--------------- | :--------------- |
+| :heart:         | 2             | N/A                | 4+               | N/A              |
+| :hourglass:     | 1             | 1.12               | 0.10–6           | 2016-12-05       |
+
+If you're opening issues related to these, please mention the version that the issue relates to.
+
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Pa11y Dashboard is a web interface to the [Pa11y][pa11y] accessibility reporter;
 Setup
 -----
 
-Pa11y Dashboard requires [Node.js][node] 0.10+ and [PhantomJS][phantom]. See the [Pa11y][pa11y] documentation for detailed instructions on how to install these dependencies on your operating system.
+Pa11y Dashboard requires [Node.js][node] 4+ and [PhantomJS][phantom]. See the [Pa11y][pa11y] documentation for detailed instructions on how to install these dependencies on your operating system.
 
 You'll also need to have [MongoDB][mongo] installed and running. See the [MongoDB install guide][mongo-install] for more information on this.
 
@@ -138,6 +138,6 @@ Copyright &copy; 2013–2016, Springer Nature
 [info-node]: package.json
 [info-build]: https://travis-ci.org/pa11y/dashboard
 [shield-license]: https://img.shields.io/badge/license-GPL%203.0-blue.svg
-[shield-node]: https://img.shields.io/badge/node.js%20support-0.10–6-brightgreen.svg
+[shield-node]: https://img.shields.io/badge/node.js%20support-4–6-brightgreen.svg
 [shield-version]: https://img.shields.io/badge/version-1.12.1-blue.svg
 [shield-build]: https://img.shields.io/travis/pa11y/dashboard/master.svg

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	"bugs": "https://github.com/pa11y/dashboard/issues",
 
 	"engines": {
-		"node": ">=0.10"
+		"node": ">=4"
 	},
 	"dependencies": {
 		"body-parser": "~1.15",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"express": "~4.13",
 		"express-hbs": "~1.0",
 		"moment": "~2.13",
-		"pa11y-webservice": "~1.11",
+		"pa11y-webservice": "~2.0",
 		"pa11y-webservice-client-node": "~1.2",
 		"underscore": "~1.8"
 	},


### PR DESCRIPTION
Not ready for merging yet, but this branch will become Pa11y Dashboard 2.0. I've changed the support levels for now, we can make any ES6 updates in a later PR. Resolves #133.
