### PR TITLE
Update several packages in order to fix several vulns

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"express": "~4.14",
 		"express-hbs": "~1.0",
 		"moment": "~2.13",
-		"pa11y-webservice": "~2.0",
+		"pa11y-webservice": "^2.0.1",
 		"pa11y-webservice-client-node": "~1.2",
 		"underscore": "~1.8"
 	},

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"express-hbs": "~1.0",
 		"moment": "~2.13",
 		"pa11y-webservice": "^2.0.1",
-		"pa11y-webservice-client-node": "~1.2",
+		"pa11y-webservice-client-node": "^1.2.1",
 		"underscore": "~1.8"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"less": "~2.7",
 		"mocha": "^2",
 		"proclaim": "^3",
-		"request": "^2",
+		"request": "^2.74",
 		"uglify-js": "~2.6"
 	},
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"jscs": "^2",
 		"jshint": "^2",
 		"less": "~2.7",
-		"mocha": "^2",
+		"mocha": "^3",
 		"proclaim": "^3",
 		"request": "^2.74",
 		"uglify-js": "~2.6"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"body-parser": "~1.15",
 		"chalk": "~1.1",
 		"compression": "~1.6",
-		"express": "~4.13",
+		"express": "~4.14",
 		"express-hbs": "~1.0",
 		"moment": "~2.13",
 		"pa11y-webservice": "~2.0",


### PR DESCRIPTION
Yes, this introduces some inconsistencies in the way that we specify versions in the package.json.

Unfortunately, this is the only way to ensure that we'll prevent users from installing a dependency that has security vulnerabilities so, we'll have to deal with it (•_•) ( •_•)>⌐■-■ (⌐■_■)
