### PR TITLE
Make optional fields optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"jscs": "^2",
 		"jshint": "^2",
 		"less": "~2.7",
-		"mocha": "^3",
+		"mocha": "^2",
 		"proclaim": "^3",
 		"request": "^2.74",
 		"uglify-js": "~2.6"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"express": "~4.14",
 		"express-hbs": "~1.0",
 		"moment": "~2.13",
-		"pa11y-webservice": "^2.0.1",
+		"pa11y-webservice": "^2.1.1",
 		"pa11y-webservice-client-node": "^1.2.1",
 		"underscore": "~1.8"
 	},

--- a/route/new.js
+++ b/route/new.js
@@ -41,10 +41,10 @@ function route(app) {
 			url: req.body.url,
 			standard: req.body.standard,
 			ignore: req.body.ignore || [],
-			timeout: req.body.timeout,
-			wait: req.body.wait,
-			username: req.body.username,
-			password: req.body.password
+			timeout: req.body.timeout || undefined,
+			wait: req.body.wait || undefined,
+			username: req.body.username || undefined,
+			password: req.body.password || undefined
 		};
 		app.webservice.tasks.create(newTask, (err, task) => {
 			if (err) {

--- a/route/task/edit.js
+++ b/route/task/edit.js
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Pa11y Dashboard.  If not, see <http://www.gnu.org/licenses/>.
 
+/*jshint maxcomplexity:8*/
+
 'use strict';
 
 const presentTask = require('../../view/presenter/task');
@@ -55,6 +57,10 @@ function route(app) {
 				return next();
 			}
 			req.body.ignore = req.body.ignore || [];
+			req.body.timeout = req.body.timeout || undefined;
+			req.body.wait = req.body.wait || undefined;
+			req.body.username = req.body.username || undefined;
+			req.body.password = req.body.password || undefined;
 			app.webservice.task(req.params.id).edit(req.body, err => {
 				if (err) {
 					task.name = req.body.name;


### PR DESCRIPTION
This fixes an issue that required people to manually specify a timeout
and wait for their tasks when they're created.