### PR TITLE
Add manifest file and .cfignore

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,1 @@
+node_modules

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,12 @@
+---
+applications:
+- name: pa11y-dashboard
+  memory: "1G"
+  disk_quota: "384M"
+  instances: 1
+
+  env:
+    NODE_ENV: development
+
+  services:
+  - pa11y-mongodb


### PR DESCRIPTION
This allows us to manually deploy pa11y-dashboard to CF.

Some work is still needed in order to make it deployable using GoCD.