### PR TITLE
Fix Travis CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ Copyright &copy; 2013–2017, Team Pa11y
 
 [info-license]: LICENSE
 [info-node]: package.json
-[info-build]: https://travis-ci.org/pa11y/dashboard
+[info-build]: https://travis-ci.org/pa11y/pa11y-dashboard
 [shield-license]: https://img.shields.io/badge/license-GPL%203.0-blue.svg
 [shield-node]: https://img.shields.io/badge/node.js%20support-4–6-brightgreen.svg
 [shield-version]: https://img.shields.io/badge/version-2.2.1-blue.svg
-[shield-build]: https://img.shields.io/travis/pa11y/dashboard/master.svg
+[shield-build]: https://img.shields.io/travis/pa11y/pa11y-dashboard/master.svg


### PR DESCRIPTION
This is currently pointing to `pa11y/dashboard` which I assume was an old name for the repository.