### PR TITLE
Add debugging info to startup log

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,8 +51,10 @@ require('./app')(config, (error, app) => {
 
 			console.log('');
 			console.log(chalk.underline.cyan('Pa11y Webservice started'));
-			console.log(chalk.grey('mode: %s'), process.env.NODE_ENV);
-			console.log(chalk.grey('uri:  %s'), webservice.server.info.uri);
+			console.log(chalk.grey('mode:     %s'), process.env.NODE_ENV);
+			console.log(chalk.grey('uri:      %s'), webservice.server.info.uri);
+			console.log(chalk.grey('database: %s'), config.webservice.database);
+			console.log(chalk.grey('cron:     %s'), config.webservice.cron);
 		});
 	}
 


### PR DESCRIPTION
This PR is the same as https://github.com/pa11y/pa11y-webservice/pull/66 but for pa11y-dashboard, as it has it's own webservice debugging info.

There are two ways of setting a configuration for this app: config files, and environment variables. This makes it easy for the app to run with a different config from the one that you intend to run it with.

Currently, only the NODE_ENV variable and server url are being printed out on startup:

![screen shot 2019-01-17 at 18 09 10](https://user-images.githubusercontent.com/1792637/51338968-2547a100-1a83-11e9-9fe4-0ce65e2b3915.png)

This PR adds the database config and the cron config to the details being displayed. This may help debug configuration issues, database issues, and specially making easier to understand what config is being used when for example running in a container.

![screen shot 2019-01-17 at 18 09 40](https://user-images.githubusercontent.com/1792637/51338983-2bd61880-1a83-11e9-9937-d6418c3ae08f.png)
