### PR TITLE
Update dependencies

### DIFF
--- a/Makefile.node
+++ b/Makefile.node
@@ -21,7 +21,7 @@
 NPM_BIN = ./node_modules/.bin
 export PATH := $(NPM_BIN):$(PATH)
 export EXPECTED_COVERAGE := 90
-export INTEGRATION_TIMEOUT := 5000
+export INTEGRATION_TIMEOUT := 10000
 export INTEGRATION_SLOW := 4000
 
 

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "express": "^4.16.3",
     "http-headers": "^3.0.1",
     "moment": "^2.22.2",
-    "pa11y-webservice-client-node": "^1.2.1",
-    "pa11y-webservice": "^2.3.1",
+    "pa11y-webservice-client-node": "^2.0.0",
+    "pa11y-webservice": "^3.0.0",
     "underscore": "~1.8"
   },
   "devDependencies": {

--- a/test/integration/route/index.js
+++ b/test/integration/route/index.js
@@ -40,10 +40,11 @@ describe.only('GET /', function() {
 
 	it('should display all of the expected tasks', function() {
 		const tasks = this.last.dom('[data-test=task]');
-		assert.strictEqual(tasks.length, 3);
+		assert.strictEqual(tasks.length, 4);
 		assert.match(tasks.eq(0).text(), /npg home\s+\(wcag2aa\)/i);
 		assert.match(tasks.eq(1).text(), /npg home\s+\(wcag2aaa\)/i);
 		assert.match(tasks.eq(2).text(), /nature news\s+\(section508\)/i);
+		assert.match(tasks.eq(3).text(), /z integration test\s+\(wcag2aa\)/i);
 	});
 
 	it('should have links to each task', function() {
@@ -51,6 +52,7 @@ describe.only('GET /', function() {
 		assert.strictEqual(tasks.eq(0).find('[href="/abc000000000000000000001"]').length, 1);
 		assert.strictEqual(tasks.eq(1).find('[href="/abc000000000000000000002"]').length, 1);
 		assert.strictEqual(tasks.eq(2).find('[href="/abc000000000000000000003"]').length, 1);
+		assert.strictEqual(tasks.eq(3).find('[href="/abc000000000000000000004"]').length, 1);
 	});
 
 	it('should display an "Edit" button for each task', function() {
@@ -58,6 +60,7 @@ describe.only('GET /', function() {
 		assert.strictEqual(tasks.eq(0).find('[href="/abc000000000000000000001/edit"]').length, 1);
 		assert.strictEqual(tasks.eq(1).find('[href="/abc000000000000000000002/edit"]').length, 1);
 		assert.strictEqual(tasks.eq(2).find('[href="/abc000000000000000000003/edit"]').length, 1);
+		assert.strictEqual(tasks.eq(3).find('[href="/abc000000000000000000004/edit"]').length, 1);
 	});
 
 	it('should display a "Delete" button for each task', function() {
@@ -65,6 +68,7 @@ describe.only('GET /', function() {
 		assert.strictEqual(tasks.eq(0).find('[href="/abc000000000000000000001/delete"]').length, 1);
 		assert.strictEqual(tasks.eq(1).find('[href="/abc000000000000000000002/delete"]').length, 1);
 		assert.strictEqual(tasks.eq(2).find('[href="/abc000000000000000000003/delete"]').length, 1);
+		assert.strictEqual(tasks.eq(3).find('[href="/abc000000000000000000004/delete"]').length, 1);
 	});
 
 	it('should display a "Run" button for each task', function() {
@@ -72,6 +76,7 @@ describe.only('GET /', function() {
 		assert.strictEqual(tasks.eq(0).find('[href="/abc000000000000000000001/run"]').length, 1);
 		assert.strictEqual(tasks.eq(1).find('[href="/abc000000000000000000002/run"]').length, 1);
 		assert.strictEqual(tasks.eq(2).find('[href="/abc000000000000000000003/run"]').length, 1);
+		assert.strictEqual(tasks.eq(3).find('[href="/abc000000000000000000004/run"]').length, 1);
 	});
 
 	it('should display the task result counts if the task has been run', function() {


### PR DESCRIPTION
Bumps pa11y-webservice and client to the new versions requiring node 8+.

Fixes the tests to account for the new `localhost` URL in the integration tests.

Increases the testing timeout to 10000 ms in order to avoid (spurious) test failures in Travis.