### PR TITLE
Fix incorrect values being passed to ObjectID()

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,7 +93,6 @@ function initApp(config, callback) {
 	// Load routes
 	require('./route/index')(app);
 	require('./route/task/index')(app);
-	require('./route/result/index')(app);
 	require('./route/result/download')(app);
 	if (!config.readonly) {
 		require('./route/new')(app);
@@ -103,6 +102,8 @@ function initApp(config, callback) {
 		require('./route/task/ignore')(app);
 		require('./route/task/unignore')(app);
 	}
+	// Needs to be loaded after `/route/task/edit`
+	require('./route/result/index')(app);
 
 	// Error handling
 	app.express.get('*', (request, response) => {

--- a/view/layout/default.html
+++ b/view/layout/default.html
@@ -27,7 +27,7 @@ along with Pa11y Dashboard.  If not, see <http://www.gnu.org/licenses/>.
 
 	{{#if noindex}}<meta name="robots" content="noindex"/>{{/if}}
 
-	<link rel="icon" type="image/png" href="favicon.png" />
+	<link rel="icon" type="image/png" href="/favicon.png" />
 
 	<!-- For mobile devices. -->
 	<meta name="viewport" content="width=device-width"/>


### PR DESCRIPTION
Due to the routes being defined in the wrong order, certain urls (e.g. `/tasks/:taskid:/edit`) are being captured by the results route instead (e.g. `/tasks/:taskid:/:resultid:`). This is causing the wrong method to being called with parts of the path like `edit`, `run`, etc. being passed as an argument to ObjectID(). As these are not valid MongoDB IDs, the method displays instead an error message:

> Argument passed in must be a single String of 12 bytes or a string of 24 hex characters

Also change the path to the favicon image to be not relative, as this is causing a `favicon.png` string to be sent as an argument to ObjectID() when visiting certain pages due to the previous issue.