### PR TITLE
Reorder the routes to avoid MongoDB ObjectID error

### DIFF
--- a/app.js
+++ b/app.js
@@ -92,7 +92,6 @@ function initApp(config, callback) {
 
 	// Load routes
 	require('./route/index')(app);
-	require('./route/task/index')(app);
 	require('./route/result/download')(app);
 	if (!config.readonly) {
 		require('./route/new')(app);
@@ -102,6 +101,8 @@ function initApp(config, callback) {
 		require('./route/task/ignore')(app);
 		require('./route/task/unignore')(app);
 	}
+	// Needs to be loaded after `/route/new`
+	require('./route/task/index')(app);
 	// Needs to be loaded after `/route/task/edit`
 	require('./route/result/index')(app);
 


### PR DESCRIPTION
When trying to add a new URL, the Node.js MongoDB driver complains with the following error:
```
ObjectID generation failed. Argument passed in must be a single String of 12 bytes or a string of 24 hex characters
```

This is because the `/new` url gets captured by the `/:id` route defined in `/route/task/index.js`. It's another instance of #244 that I missed when fixing it.