### PR TITLE
Add request logging using morgan

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "http-headers": "~3.0.2",
     "kleur": "~4.1.4",
     "moment": "~2.29.1",
+    "morgan": "~1.10.0",
+    "nanoid": "~3.3.1",
     "pa11y-webservice": "~4.0.0",
     "pa11y-webservice-client-node": "~3.0.0",
     "underscore": "~1.13.1"


### PR DESCRIPTION
This commit adds request logging to the app using `morgan`.

Every request will now be logged not one but twice: one when the request is received, and a second time when the response is sent, e.g.:

```
[2022-03-07T18:32:22.037Z #OxqLbfke7A] Started GET /60702901e81843006366cc9c for ::ffff:127.0.0.1
[2022-03-07T18:32:23.759Z #OxqLbfke7A] Completed 200 - in 1716.344 ms
```

The response logging also prints out the time elapsed in processing the request, which will be useful to debug performance issues (calls to the dashboard home are currently taking 4 - 15s on a populated database).

The new code uses a tiny middleware that uses nanoid to generate a random request id (`#OxqLbfke7A` in the example) that can be used to match requests in the logs.

This logging will help us determine which requests are successful, which requests are slow, and establish what requests may have contributed to causing an application crash, making future debugging easier.

I've decided against using existing middleware like `express-request-id` as the version of the middleware that I needed is literally 2 lines of code.