### PR TITLE
Address all eslint warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ require('./app')(config, (error, app) => {
 	console.log(kleur.grey('mode: %s'), process.env.NODE_ENV);
 	console.log(kleur.grey('uri:  %s'), app.address);
 
-	app.on('route-error', error => {
-		const stack = (error.stack ? error.stack.split('\n') : [error.message]);
+	app.on('route-error', routeError => {
+		const stack = (routeError.stack ? routeError.stack.split('\n') : [routeError.message]);
 		const msg = kleur.red(stack.shift());
 		console.error('');
 		console.error(msg);
@@ -43,9 +43,9 @@ require('./app')(config, (error, app) => {
 
 	// Start the webservice if required
 	if (typeof config.webservice === 'object') {
-		require('pa11y-webservice')(config.webservice, (error, webservice) => {
-			if (error) {
-				console.error(error.stack);
+		require('pa11y-webservice')(config.webservice, (webserviceError, webservice) => {
+			if (webserviceError) {
+				console.error(webserviceError.stack);
 				process.exit(1);
 			}
 

--- a/route/new.js
+++ b/route/new.js
@@ -30,42 +30,21 @@ function route(app) {
 			return standard;
 		});
 		response.render('new', {
-			standards: standards,
+			standards,
 			isNewTaskPage: true
 		});
 	});
 
 	app.express.post('/new', (request, response) => {
 
-		let parsedActions;
-		if (request.body.actions) {
-			parsedActions = request.body.actions.split(/[\r\n]+/)
-				.map(action => {
-					return action.trim();
-				})
-				.filter(action => {
-					return Boolean(action);
-				});
-		}
-
+		const parsedActions = parseActions(request.body.actions);
 		let parsedHeaders;
+
 		if (request.body.headers) {
 			parsedHeaders = httpHeaders(request.body.headers, true);
 		}
 
-		const newTask = {
-			name: request.body.name,
-			url: request.body.url,
-			standard: request.body.standard,
-			ignore: request.body.ignore || [],
-			timeout: request.body.timeout || undefined,
-			wait: request.body.wait || undefined,
-			actions: parsedActions,
-			username: request.body.username || undefined,
-			password: request.body.password || undefined,
-			headers: parsedHeaders,
-			hideElements: request.body.hideElements || undefined
-		};
+		const newTask = createNewTask(request, parsedActions, parsedHeaders);
 
 		app.webservice.tasks.create(newTask, (error, task) => {
 			if (error) {
@@ -84,8 +63,8 @@ function route(app) {
 				newTask.actions = request.body.actions;
 				newTask.headers = request.body.headers;
 				return response.render('new', {
-					error: error,
-					standards: standards,
+					error,
+					standards,
 					task: newTask
 				});
 			}
@@ -93,4 +72,33 @@ function route(app) {
 		});
 	});
 
+}
+
+function parseActions(actions) {
+	if (actions) {
+		return actions.split(/[\r\n]+/)
+			.map(action => {
+				return action.trim();
+			})
+			.filter(action => {
+				return Boolean(action);
+			});
+	}
+}
+
+/* eslint-disable complexity */
+function createNewTask(request, actions, headers) {
+	return {
+		name: request.body.name,
+		url: request.body.url,
+		standard: request.body.standard,
+		ignore: request.body.ignore || [],
+		timeout: request.body.timeout || undefined,
+		wait: request.body.wait || undefined,
+		actions,
+		username: request.body.username || undefined,
+		password: request.body.password || undefined,
+		headers,
+		hideElements: request.body.hideElements || undefined
+	};
 }

--- a/route/result/download.js
+++ b/route/result/download.js
@@ -29,8 +29,8 @@ function route(app) {
 			app.webservice
 				.task(request.params.id)
 				.result(request.params.rid)
-				.get({full: true}, (error, result) => {
-					if (error) {
+				.get({full: true}, (webserviceError, result) => {
+					if (webserviceError) {
 						return next('route');
 					}
 					response.locals.task = task;

--- a/route/result/index.js
+++ b/route/result/index.js
@@ -30,8 +30,8 @@ function route(app) {
 			app.webservice
 				.task(request.params.id)
 				.result(request.params.rid)
-				.get({full: true}, (error, result) => {
-					if (error) {
+				.get({full: true}, (webserviceError, result) => {
+					if (webserviceError) {
 						return next();
 					}
 					response.render('result', {

--- a/route/task/edit.js
+++ b/route/task/edit.js
@@ -43,13 +43,15 @@ function route(app) {
 			task.actions = (task.actions ? task.actions.join('\n') : '');
 			response.render('task/edit', {
 				edited: (typeof request.query.edited !== 'undefined'),
-				standards: standards,
+				standards,
 				task: presentTask(task),
 				isTaskSubPage: true
 			});
 		});
 	});
 
+	/* eslint-disable complexity */
+	/* eslint-disable max-statements */
 	app.express.post('/:id/edit', (request, response, next) => {
 		app.webservice.task(request.params.id).get({}, (error, task) => {
 			if (error) {
@@ -57,9 +59,11 @@ function route(app) {
 			}
 			const originalActions = request.body.actions;
 			const originalHeaders = request.body.headers;
+
 			request.body.ignore = request.body.ignore || [];
 			request.body.timeout = request.body.timeout || undefined;
 			request.body.wait = request.body.wait || undefined;
+
 			if (request.body.actions) {
 				request.body.actions = request.body.actions.split(/[\r\n]+/)
 					.map(action => {
@@ -69,15 +73,18 @@ function route(app) {
 						return Boolean(action);
 					});
 			}
+
 			if (!request.body.actions) {
 				request.body.actions = [];
 			}
+
 			request.body.username = request.body.username || undefined;
 			request.body.password = request.body.password || undefined;
 			request.body.hideElements = request.body.hideElements || undefined;
 			request.body.headers = httpHeaders(request.body.headers || '', true);
-			app.webservice.task(request.params.id).edit(request.body, error => {
-				if (error) {
+
+			app.webservice.task(request.params.id).edit(request.body, webserviceError => {
+				if (webserviceError) {
 					task.name = request.body.name;
 					task.ignore = request.body.ignore;
 					task.timeout = request.body.timeout;
@@ -100,9 +107,9 @@ function route(app) {
 						return standard;
 					});
 					return response.render('task/edit', {
-						error: error,
-						standards: standards,
-						task: task,
+						webserviceError,
+						standards,
+						task,
 						isTaskSubPage: true
 					});
 				}

--- a/route/task/index.js
+++ b/route/task/index.js
@@ -28,9 +28,9 @@ function route(app) {
 			if (error) {
 				return next();
 			}
-			app.webservice.task(request.params.id).results({}, (error, results) => {
-				if (error) {
-					return next(error);
+			app.webservice.task(request.params.id).results({}, (webserviceError, results) => {
+				if (webserviceError) {
+					return next(webserviceError);
 				}
 				const presentedResults = presentResultList(results.map(presentResult));
 				response.render('task', {

--- a/view/presenter/ignore.js
+++ b/view/presenter/ignore.js
@@ -22,7 +22,7 @@ module.exports = presentIgnoreRules;
 function presentIgnoreRules(ignore) {
 	return ignore.map(name => {
 		return {
-			name: name,
+			name,
 			description: rules[name]
 		};
 	});


### PR DESCRIPTION
Address all eslint warnings that were still present by:

* Extracting code to a new function in order to reduce complexity
* Renamed error variables and use shorthand notation for objects
* Disabling eslint warnings where addressing the issue would require too much refactoring