### PR TITLE
In workflow, update default branch to `main`, use `ubuntu-20.04`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,15 +1,10 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests.
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Build and lint
 
 on:
   push:
-    branches: # Run actions when code is committed to these branches
-      - master
+    branches:
+      - main
   pull_request:
-    branches: # Run actions when a PR is pushed based on one of these branches
-      - master
 
 jobs:
   checkout_and_test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   checkout_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:


### PR DESCRIPTION
> [!WARNING]
> Instamerge to follow with forgiveness requested.
> But reviewed elsewhere for other repos, keeping it minimal here, and workflow is running again/passing.

---

Minimal workflow updates to bring build closer to working again:

- workflow trigger: use `main` in place of `master` for default branch name
- anticipate build error: use `ubuntu-20.04` in place of `ubuntu-latest`, to match its use in `pa11y-webservice` until `pa11y@7` is released

