### PR TITLE
Release `pa11y-dashboard@5.0.0`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 12
       - run: npm ci
@@ -32,8 +32,8 @@ jobs:
           - { node: 12, mongo: 2.6.12 }
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
       - run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
   test:
     name: test (node ${{ matrix.node }}, mongodb ${{ matrix.mongo }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,11 @@ jobs:
           - { node: 20, mongo: 2.6.12 }
 
     steps:
+      - name: Disable AppArmor User Namespace Restrictions, required to open
+          Chrome on Ubuntu 23.10+ without --no-sandbox). See
+          https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md.
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
   test:
     name: test (node ${{ matrix.node }}, mongodb ${{ matrix.mongo }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
-          node-version: 12
+          node-version: 20
       - run: npm ci
       - run: npm run lint
 
@@ -21,15 +21,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 14, 16, 18, 20]
+        node: [20, 22, 24]
         mongo: [latest]
         include:
-          - { node: 12, mongo: 7.0.25 }
-          - { node: 12, mongo: 6.0.11 }
-          - { node: 12, mongo: 5.0.22 }
-          - { node: 12, mongo: 4.4.25 }
-          - { node: 12, mongo: 3.6.23 }
-          - { node: 12, mongo: 2.6.12 }
+          - { node: 20, mongo: 7.0.25 }
+          - { node: 20, mongo: 6.0.11 }
+          - { node: 20, mongo: 5.0.22 }
+          - { node: 20, mongo: 4.4.25 }
+          - { node: 20, mongo: 3.6.23 }
+          - { node: 20, mongo: 2.6.12 }
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
         node: [12, 14, 16, 18, 20]
         mongo: [latest]
         include:
+          - { node: 12, mongo: 7.0.25 }
           - { node: 12, mongo: 6.0.11 }
           - { node: 12, mongo: 5.0.22 }
           - { node: 12, mongo: 4.4.25 }
@@ -38,7 +39,7 @@ jobs:
       - run: npm ci
 
       - name: Supply MongoDB ${{ matrix.mongo }}
-        uses: supercharge/mongodb-github-action@1.5.0
+        uses: supercharge/mongodb-github-action@1.12.0
         with:
           mongodb-version: ${{ matrix.mongo }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,27 @@
 # Changelog
 
-## 4.3.0 (DATE)
+## 4.3.0 (2024-03-26)
 
-* DESCRIPTION
+### Changes
+
+* Improve console messaging (thanks @sangitamane)
+* Address linting issues (thanks @josebolos and @hollsk)
+* Various accessibility improvements to dashboard pages (thanks @sangitamane)
+* Improve version support and its verification
+  * Support Node 16-20
+  * Support MongoDB `2`, `4`, `5`, `6`, `latest`
+  * Fix various integration test issues
+  * Add info to readme about Ubuntu `> 20.04` workaround (issue will be fixed by `pa11y-dashboard@5.0.0`)
+* Minor dependency upgrades
+* Update support policy
+
+### New contributors
+
+* @danyalaytekin made their first contribution in https://github.com/pa11y/pa11y-dashboard/pull/315
+
+### Full diff
+
+* [4.2.0...4.3.0](https://github.com/pa11y/pa11y-dashboard/compare/4.2.0...4.3.0)
 
 ## 4.2.0 (2022-03-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.0 (DATE)
+
+* DESCRIPTION
+
 ## 4.2.0 (2022-03-30)
 
 * Add request logging for easier debugging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Various accessibility improvements to dashboard pages (thanks @sangitamane)
 * Improve version support and its verification
   * Support Node 16-20
-  * Support MongoDB `2`, `4`, `5`, `6`, `latest`
+  * Support MongoDB `2`, `4`, `5`, `6`, `7`, `latest`
   * Fix various integration test issues
   * Add info to readme about Ubuntu `> 20.04` workaround (issue will be fixed by `pa11y-dashboard@5.0.0`)
 * Minor dependency upgrades

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The following table lists the major versions available and, for each previous ma
 ## License
 
 Pa11y Dashboard is licensed under the [GNU General Public License 3.0][info-license].  
-Copyright &copy; 2023, Team Pa11y and contributors
+Copyright &copy; 2016-2024, Team Pa11y and contributors
 
 [homebrew]: https://brew.sh/
 [issues]: https://github.com/pa11y/pa11y-dashboard/issues?utf8=%E2%9C%93&q=is%3Aissue

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Pa11y Dashboard is a web interface to the [Pa11y][pa11y] accessibility reporter;
 
 Pa11y (and therefore this service) uses Headless Chrome to perform accessibility testing. On Linux and other Unix-like systems, Pa11y's attempt to install it as a dependency sometimes fails since additional operating system packages will be required. Your distribution's documentation should describe how to install these.
 
-In addition, to use Pa11y Dashboard 4 with a version of Ubuntu above 20.04, a path to the Chrome executable must be defined in `chromeLaunchConfig`, as `chromeLaunchConfig.executablePath`. Version 5 of Pa11y Dashboard, which will use Pa11y 7 along with a more recent version of Puppeteer, will resolve this issue.
+In addition, to use Pa11y Dashboard 4 with a version of Ubuntu above 20.04, a path to the Chrome executable must be defined in `chromeLaunchConfig`, as `chromeLaunchConfig.executablePath`. Version 5 of Pa11y Dashboard, which will use Pa11y 8 along with a more recent version of Puppeteer, will resolve this issue.
 
 ## Setting up Pa11y Dashboard
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Pa11y Dashboard is a web interface to the [Pa11y][pa11y] accessibility reporter;
 
 Pa11y (and therefore this service) uses Headless Chrome to perform accessibility testing. On Linux and other Unix-like systems, Pa11y's attempt to install it as a dependency sometimes fails since additional operating system packages will be required. Your distribution's documentation should describe how to install these.
 
-In addition, to use Pa11y Dashboard 4 with a version of Ubuntu above 20.04, a path to the Chrome executable must be defined in `chromeLaunchConfig`, as `chromeLaunchConfig.executablePath`. Version 5 of Pa11y Dashboard, which will use Pa11y 8 along with a more recent version of Puppeteer, will resolve this issue.
+In addition, to use Pa11y Dashboard 4 with a version of Ubuntu above 20.04, a path to the Chrome executable must be defined in `chromeLaunchConfig`, as `chromeLaunchConfig.executablePath`. Version 5 of Pa11y Dashboard, which will use Pa11y 9 along with a more recent version of Puppeteer, will resolve this issue.
 
 ## Setting up Pa11y Dashboard
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install
 
 Instructions for installing and running MongoDB are outside the scope of this document. When in doubt, please refer to the [MongoDB installation instructions](https://docs.mongodb.com/manual/installation/) for details of how to install and run MongoDB on your specific operating system. An example of the installation and configuration process for macOS follows.
 
-Pa11y Dashboard uses [MongoDB Node.js Driver][mongodb-package] version 3, which [may not support some features][mongodb-package-compatibility] of MongoDB versions 6 and beyond. We do however test against MongoDB versions 2 to 6, plus the latest major version, which at the time of writing is `7`.
+Pa11y Dashboard uses [MongoDB Node.js Driver][mongodb-package] version 3, which [may not support some features][mongodb-package-compatibility] of MongoDB versions 6 and beyond. We do however test against MongoDB versions 2 to 7, plus the latest major version, which at the time of writing is `8`.
 
 #### Example MongoDB installation for macOS
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The following table lists the major versions available and, for each previous ma
 ## License
 
 Pa11y Dashboard is licensed under the [GNU General Public License 3.0][info-license].  
-Copyright &copy; 2016-2024, Team Pa11y and contributors
+Copyright &copy; 2016-2025, Team Pa11y and contributors
 
 [homebrew]: https://brew.sh/
 [issues]: https://github.com/pa11y/pa11y-dashboard/issues?utf8=%E2%9C%93&q=is%3Aissue

--- a/README.md
+++ b/README.md
@@ -188,12 +188,12 @@ When we release a new major version we will continue to support the previous maj
 
 The following table lists the major versions available and, for each previous major version, its end-of-support date, and its final minor version released.
 
-| Major version | Last minor release | Node.js support             | Support end date |
-| :------------ | :----------------- | :------------------------ | :--------------- |
-| `4`           | Imminent           | `>= 12`                     | ✅ Current major version |
-| `3`           | `3.3.0`            | `8`, `10`                   | 2022-05-26       |
-| `2`           | `2.4.2`            | `4`, `6`                    | 2020-01-16       |
-| `1`           | `1.12.0`           | `0.10`, `0.12`, `4`, `6`    | 2016-12-05       |
+| Major version | Last minor release | Node.js support              | Support end date |
+| :------------ | :----------------- | :--------------------------- | :--------------- |
+| `4`           | `4.3`              | `12`, `14`, `16`, `18`, `20` | ✅ Current major version |
+| `3`           | `3.3`              | `8`, `10`                    | 2022-05-26       |
+| `2`           | `2.4`              | `4`, `6`                     | 2020-01-16       |
+| `1`           | `1.12`             | `0.10`, `0.12`, `4`, `6`     | 2016-12-05       |
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pa11y-dashboard",
-  "version": "4.3.0",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pa11y-dashboard",
-      "version": "4.3.0",
+      "version": "5.0.0",
       "license": "GPL-3.0",
       "dependencies": {
         "body-parser": "~1.19.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pa11y-dashboard",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pa11y-dashboard",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "license": "GPL-3.0",
       "dependencies": {
         "body-parser": "~1.19.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-dashboard",
-  "version": "4.3.0",
+  "version": "5.0.0",
   "private": true,
   "description": "Pa11y Dashboard is a visual web interface to the Pa11y accessibility reporter",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-dashboard",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "private": true,
   "description": "Pa11y Dashboard is a visual web interface to the Pa11y accessibility reporter",
   "keywords": [


### PR DESCRIPTION
> [!NOTE]
> 1. `pa11y-dashboard@5.0.0` will be tagged on `main`, when this PR has been merged, by publishing the [draft GitHub Release](https://github.com/pa11y/pa11y-dashboard/releases).  The project isn't currently hosted in npm.  
> 2. [Full diff since `4.2.0`](https://github.com/pa11y/pa11y-dashboard/compare/4.2.0...release-4.3.0)
> 3. The branch name is `release-4.3.0`, which is inaccurate... we proceed.

### Components

- [x] #292 
- [x] #299 
- [x] #306 
- [x] #318
- [x] #323 
- [x] Many dependency bumps by dependabot
- [x] #340 

### Changes in this PR

- [x] Update `package*.json`
- [x] Add `CHANGELOG.md` entry
- [x] Update `README.md`
- [x] Create [draft release](https://github.com/pa11y/pa11y-dashboard/releases)

### External dependencies

- [x] https://github.com/pa11y/pa11y-webservice/pull/159
- [x] https://github.com/pa11y/pa11y-webservice-client-node/pull/29