### PR TITLE
Add support for basic authentication

### DIFF
--- a/config/development.sample.json
+++ b/config/development.sample.json
@@ -2,6 +2,11 @@
 	"port": 4000,
 	"noindex": true,
 	"readonly": false,
+	"protection": {
+		"enabled": false,
+		"user": "pa11y",
+		"pass": "pa11y"
+	},
 	"webservice": {
 		"database": "mongodb://localhost/pa11y-webservice-dev",
 		"host": "0.0.0.0",

--- a/config/production.sample.json
+++ b/config/production.sample.json
@@ -2,6 +2,11 @@
 	"port": 4000,
 	"noindex": true,
 	"readonly": false,
+	"protection": {
+		"enabled": true,
+		"user": "pa11y",
+		"pass": "pa11y"
+	},
 	"webservice": {
 		"database": "mongodb://localhost/pa11y-webservice",
 		"host": "0.0.0.0",

--- a/config/test.sample.json
+++ b/config/test.sample.json
@@ -2,6 +2,11 @@
 	"port": 4000,
 	"noindex": true,
 	"readonly": false,
+	"protection": {
+		"enabled": false,
+		"user": "pa11y",
+		"pass": "pa11y"
+	},
 	"webservice": {
 		"database": "mongodb://127.0.0.1/pa11y-dashboard-integration-test",
 		"host": "127.0.0.1",


### PR DESCRIPTION
I've added support for basic authentication. This can be useful when setting up pa11y-dashboard using a custom domain which shall be accessible from any source.