### PR TITLE
Add support for basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ The boot configurations for Pa11y Dashboard are as follows. Look at the sample J
 
 *(boolean)* If set to `true`, users will not be able to add, delete or run URLs (defaults to `false`). Set via a config file or the `READONLY` environment variable.
 
+### `protection`
+
+*(boolean)* If set to `true`, the dashboard will be protected by a basic authentication popup. This can be useful when setting up Pa11y Dashboard in combination with a public custom domain. Be sure to change your username and password accordingly.
+
 ### `siteMessage`
 
 *(string)* A message to display prominently on the site home page. Defaults to `null`.

--- a/app.js
+++ b/app.js
@@ -41,6 +41,10 @@ function initApp(config, callback) {
 	app.server = http.createServer(app.express);
 	app.webservice = createClient(webserviceUrl);
 
+	// Apply basic authentication if necessary
+	loadBasicAuth(app, config);
+
+	// Load middleware
 	loadMiddleware(app);
 
 	// View engine
@@ -61,6 +65,34 @@ function defaultConfig(config) {
 		config.readonly = false;
 	}
 	return config;
+}
+
+function loadBasicAuth(app, config) {
+	app.express.use((request, response, next) => {
+		const protection = config.protection.enabled || false;
+		if (protection) {
+			const auth = request.headers.authorization;
+			if (!auth) {
+				// Prompt the user for credentials
+				response.set('WWW-Authenticate', 'Basic realm="401"');
+				return response.status(401).send('Authentication required.');
+			}
+
+			const credentials = Buffer.from(auth.split(' ')[1], 'base64').toString().split(':');
+			const [username, password] = credentials;
+
+			// Use credentials from config
+			const USER = config.protection.user || '';
+			const PASS = config.protection.pass || '';
+
+			if (username === USER && password === PASS) {
+				return next(); // Proceed to the next middleware or route
+			}
+			response.set('WWW-Authenticate', 'Basic realm="401"'); // Prompt again
+			return response.status(401).send('Authentication required.');
+		}
+		return next();
+	});
 }
 
 function loadMiddleware(app) {

--- a/config/development.sample.json
+++ b/config/development.sample.json
@@ -2,6 +2,11 @@
 	"port": 4000,
 	"noindex": true,
 	"readonly": false,
+	"protection": {
+		"enabled": false,
+		"user": "pa11y",
+		"pass": "pa11y"
+	},
 	"webservice": {
 		"database": "mongodb://localhost/pa11y-webservice-dev",
 		"host": "0.0.0.0",

--- a/config/production.sample.json
+++ b/config/production.sample.json
@@ -2,6 +2,11 @@
 	"port": 4000,
 	"noindex": true,
 	"readonly": false,
+	"protection": {
+		"enabled": true,
+		"user": "pa11y",
+		"pass": "pa11y"
+	},
 	"webservice": {
 		"database": "mongodb://localhost/pa11y-webservice",
 		"host": "0.0.0.0",

--- a/config/test.sample.json
+++ b/config/test.sample.json
@@ -2,6 +2,11 @@
 	"port": 4000,
 	"noindex": true,
 	"readonly": false,
+	"protection": {
+		"enabled": false,
+		"user": "pa11y",
+		"pass": "pa11y"
+	},
 	"webservice": {
 		"database": "mongodb://127.0.0.1/pa11y-dashboard-integration-test",
 		"host": "127.0.0.1",


### PR DESCRIPTION
I've added support for basic authentication. This can be useful when setting up pa11y-dashboard using a custom domain which shall be accessible from any source.