### PR TITLE
add docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:18
+
+# Install Chrome dependencies
+RUN apt-get update && apt-get install -y \
+    wget \
+    gnupg \
+    ca-certificates \
+    apt-transport-https \
+    build-essential \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install --production
+
+# Copy application files
+COPY . .
+
+# Expose the application port
+EXPOSE 4000
+
+# Set environment variables
+ENV NODE_ENV=production
+
+CMD ["node", "index.js"]

--- a/README.md
+++ b/README.md
@@ -115,6 +115,65 @@ The [available configurations](#configurations) are documented in the next secti
 
 If you run into problems, check the [troubleshooting guide](#troubleshooting).
 
+#### Option 3: Using Docker
+
+Pa11y Dashboard can also be run using Docker. We provide a `docker-compose.yml` file that sets up both Pa11y Dashboard and MongoDB services.
+
+1. Make sure you have [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) installed.
+
+2. Clone the repository and navigate to it:
+```sh
+git clone https://github.com/pa11y/pa11y-dashboard.git
+cd pa11y-dashboard
+```
+
+3. add configuration file at `config/production.json`
+```json
+{
+    "port": 4000,
+    "noindex": true,
+    "readonly": false,
+    "webservice": {
+        "database": "mongodb://mongo/pa11y-webservice",
+        "host": "0.0.0.0",
+        "port": 3000,
+        "chromeLaunchConfig": {
+            "ignoreHTTPSErrors": false,
+            "args": [
+                "--no-sandbox"
+            ]
+        },
+        "cron": "30 0 * * 3"
+    }
+}
+```
+
+1. Start the services:
+```sh
+docker-compose up --build
+```
+
+This will:
+- Build the Pa11y Dashboard image with all required dependencies (including Chrome)
+- Start a MongoDB container
+- Start Pa11y Dashboard and connect it to MongoDB
+- Make the dashboard available at `http://localhost:4000`
+
+To run in detached mode (in the background):
+```sh
+docker-compose up -d
+```
+
+To stop the services:
+```sh
+docker-compose down
+```
+
+The MongoDB data is persisted in a Docker volume. To completely clean up, including removing the database volume:
+```sh
+docker-compose down -v
+```
+
 ## Configurations
 
 The boot configurations for Pa11y Dashboard are as follows. Look at the sample JSON files in the repo for example usage.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+
+services:
+  pa11y-dashboard:
+    build: .
+    ports:
+      - "4000:4000"
+    environment:
+      - NODE_ENV=production
+    volumes:
+      - ./config/production.json:/app/config/production.json
+    depends_on:
+      - mongo
+
+  mongo:
+    image: mongo:6.0
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+
+volumes:
+  mongodb_data:


### PR DESCRIPTION
I have created the Docker configuration for pa11y-dashboard with the following files:

Dockerfile - Includes:

Node 18 base image
Chrome and its dependencies for pa11y
Application setup and configuration
docker-compose.yml - Defines:

pa11y-dashboard service (port 4000)
MongoDB 6.0 service (port 27017)
Volume mounts for data persistence
Configuration file mounting
Updated config/production.json with Docker-compatible MongoDB URL
updated README with docker usage instructions