### PR TITLE
Add support for environment variables for Chrome config

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ The boot configurations for Pa11y Dashboard are as follows. Look at the sample J
 
 This can either be an object containing [Pa11y Webservice configurations][pa11y-webservice-config], or a string which is the base URL of a Pa11y Webservice instance you are running separately. If using environment variables, prefix the webservice vars with `WEBSERVICE_`.
 
+### `chromeLaunchConfig`
+
+When using environment variables, the following options are available for configuring the Chromium instance launched by Pa11y:
+
+- `CHROMIUM_FLAGS`: A comma-separated list of flags to pass to Chromium. For example, `--no-sandbox,--disable-setuid-sandbox`. These are required when running in containerised environments (e.g. Docker).
+- `CHROMIUM_EXECUTABLE`: The path to a custom Chromium executable. This may be required on certain Linux distributions (see the [migration guide](MIGRATION.md) for details).
+
 ## Contributing
 
 There are many ways to contribute to Pa11y Dashboard, we cover these in the [contributing guide](CONTRIBUTING.md) for this repo.

--- a/config.js
+++ b/config.js
@@ -25,16 +25,30 @@ if (fs.existsSync(jsonPath)) {
 } else if (fs.existsSync(jsPath)) {
 	module.exports = require(jsPath);
 } else {
+	const webserviceConfig = {
+		database: env('WEBSERVICE_DATABASE', 'mongodb://localhost/pa11y-webservice'),
+		host: env('WEBSERVICE_HOST', '0.0.0.0'),
+		port: Number(env('WEBSERVICE_PORT', '3000')),
+		cron: env('WEBSERVICE_CRON', false)
+	};
+
+	const chromiumFlags = env('CHROMIUM_FLAGS', undefined);
+	const chromiumExecutable = env('CHROMIUM_EXECUTABLE', undefined);
+	if (chromiumFlags || chromiumExecutable) {
+		webserviceConfig.chromeLaunchConfig = {};
+		if (chromiumFlags) {
+			webserviceConfig.chromeLaunchConfig.args = chromiumFlags.split(',');
+		}
+		if (chromiumExecutable) {
+			webserviceConfig.chromeLaunchConfig.executablePath = chromiumExecutable;
+		}
+	}
+
 	module.exports = {
 		port: Number(env('PORT', '4000')),
 		noindex: env('NOINDEX', 'true') === 'true',
 		readonly: env('READONLY', 'false') === 'true',
-		webservice: env('WEBSERVICE_URL', {
-			database: env('WEBSERVICE_DATABASE', 'mongodb://localhost/pa11y-webservice'),
-			host: env('WEBSERVICE_HOST', '0.0.0.0'),
-			port: Number(env('WEBSERVICE_PORT', '3000')),
-			cron: env('WEBSERVICE_CRON', false)
-		})
+		webservice: env('WEBSERVICE_URL', webserviceConfig)
 	};
 }
 


### PR DESCRIPTION
This improves compliance with 12 Factor App guidelines as the Chrome config is going to be required in almost every modern environment and currently it's only possible to specify it in a config.json file.

This will help make the app easier to run in cloud or containerised environments, as you will be able to use env vars for everything rather than having to feed config files to a docker image or whatever.
