### PR TITLE
Improve app signal handling and graceful shutdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,11 +20,6 @@ const kleur = require('kleur');
 const config = require('./config');
 const initDashboard = require('./app');
 
-process.on('SIGINT', () => {
-	console.log('\nGracefully shutting down from SIGINT (Ctrl-C)');
-	process.exit();
-});
-
 initDashboard(config, (error, app) => {
 	if (error) {
 		console.error(error.stack);
@@ -33,6 +28,17 @@ initDashboard(config, (error, app) => {
 
 	const mode = process.env.NODE_ENV;
 	const dashboardAddress = app.server.address();
+
+	function gracefulShutdown(signal) {
+		console.log(`\nGracefully shutting down (${signal})`);
+		app.server.close(() => {
+			console.log('HTTP server closed');
+			process.exit(0);
+		});
+	}
+
+	process.on('SIGINT', () => gracefulShutdown('SIGINT'));
+	process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
 
 	console.log(kleur.underline().magenta('\nPa11y Dashboard started'));
 	console.log(kleur.grey('mode:               %s'), mode);


### PR DESCRIPTION
Most cloud envs will send a SIGTERM signal to the app when the pod is going to be killed (because of e.g. scaling down or a new deployment) and, after a reasonable timeout, a SIGINT signal if the app is still running.

Dashboard doesn't currently handle SIGTERM at all, so the current shutdown process is not as graceful as it could be.

This PR improves this by introducing the following changes:

- Add handling of SIGTERM so for example a running pa11y test has a chance of finishing before the app is killed.
- Move the handling of SIGINT inside initDashboard so `app` is in scope.
- Make SIGTERM/SIGINT call server.close() so the server will stop accepting new connections and wait for in-flight requests to finish, instead of just calling `process.exit`.
- Log which signal was actually received which might help with debugging in the future.
