### PR TITLE
Add new /health health check endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,7 +48,7 @@ function initApp(config, callback) {
 	loadViewEngine(app, config);
 
 	// Load routes
-	loadRoutes(app, config);
+	loadRoutes(app, config, webserviceUrl);
 
 	// Error handling
 	loadErrorHandling(app, config, callback);
@@ -134,7 +134,11 @@ function loadViewEngine(app, config) {
 	});
 }
 
-function loadRoutes(app, config) {
+function loadRoutes(app, config, webserviceUrl) {
+	// Health check endpoint (must be registered before task routes
+	// to avoid the ID parameter matching '/health' as a task ID)
+	require('./route/health')(app, webserviceUrl);
+
 	// Because there's some overlap between the different routes,
 	//  they have to be loaded in a specific order in order to avoid
 	//  passing mongo the wrong id which would result in

--- a/route/health.js
+++ b/route/health.js
@@ -1,0 +1,47 @@
+// This file is part of Pa11y Dashboard.
+//
+// Pa11y Dashboard is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Pa11y Dashboard is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Pa11y Dashboard.  If not, see <http://www.gnu.org/licenses/>.
+'use strict';
+
+// Health check endpoint for use by load balancers, container orchestrators,
+// and platform health monitors (e.g. CloudFoundry).
+// Returns 200 if webservice is reachable, or 503 otherwise.
+module.exports = function health(app, webserviceUrl) {
+	app.express.get('/health', async (request, response) => {
+		try {
+			// Ping webservice to verify that the chain
+			// Dashboard > webservice > MongoDB is operational.
+			// eslint-disable-next-line n/no-unsupported-features/node-builtins
+			const result = await fetch(webserviceUrl, {
+				// CloudFoundry for example has a 1 second timeout for the health check
+				// The 750ms timeout aims to keep us within that window
+				signal: AbortSignal.timeout(750)
+			});
+			if (result.ok) {
+				return response.status(200).json({
+					status: 'ok'
+				});
+			}
+			response.status(503).json({
+				status: 'error',
+				message: 'webservice responded with an error'
+			});
+		} catch {
+			response.status(503).json({
+				status: 'error',
+				message: 'webservice unavailable'
+			});
+		}
+	});
+};

--- a/test/integration/route/health.js
+++ b/test/integration/route/health.js
@@ -1,0 +1,47 @@
+// This file is part of Pa11y Dashboard.
+//
+// Pa11y Dashboard is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Pa11y Dashboard is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Pa11y Dashboard.  If not, see <http://www.gnu.org/licenses/>.
+'use strict';
+
+const assert = require('proclaim');
+
+describe('GET /health', function() {
+	beforeEach(function(done) {
+		const request = {
+			method: 'GET',
+			endpoint: '/health',
+			nonDom: true
+		};
+		this.navigate(request, done);
+	});
+
+	it('should send a 200 status', function() {
+		assert.strictEqual(this.last.status, 200);
+	});
+
+	it('should respond with JSON', function() {
+		const contentType = this.last.response.headers.get('content-type');
+		assert.include(contentType, 'application/json');
+	});
+
+	it('should report a healthy status', function() {
+		assert.isObject(this.last.body);
+		assert.strictEqual(this.last.body.status, 'ok');
+	});
+
+	it('should not include unexpected properties', function() {
+		const keys = Object.keys(this.last.body);
+		assert.deepStrictEqual(keys, ['status']);
+	});
+});


### PR DESCRIPTION
The endpoint pings webservice to verify that webservice and MongoDB are up and running.

This is useful for platforms like CloudFoundry that require a health check endpoint, and should be more reliable than requesting the homepage as that may be too slow.