### PR TITLE
Simplify health check endpoint liveness test

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,7 +48,7 @@ function initApp(config, callback) {
 	loadViewEngine(app, config);
 
 	// Load routes
-	loadRoutes(app, config, webserviceUrl);
+	loadRoutes(app, config);
 
 	// Error handling
 	loadErrorHandling(app, config, callback);
@@ -134,10 +134,10 @@ function loadViewEngine(app, config) {
 	});
 }
 
-function loadRoutes(app, config, webserviceUrl) {
+function loadRoutes(app, config) {
 	// Health check endpoint (must be registered before task routes
 	// to avoid the ID parameter matching '/health' as a task ID)
-	require('./route/health')(app, webserviceUrl);
+	require('./route/health')(app);
 
 	// Because there's some overlap between the different routes,
 	//  they have to be loaded in a specific order in order to avoid

--- a/route/health.js
+++ b/route/health.js
@@ -14,34 +14,12 @@
 // along with Pa11y Dashboard.  If not, see <http://www.gnu.org/licenses/>.
 'use strict';
 
-// Health check endpoint for use by load balancers, container orchestrators,
-// and platform health monitors (e.g. CloudFoundry).
-// Returns 200 if webservice is reachable, or 503 otherwise.
-module.exports = function health(app, webserviceUrl) {
-	app.express.get('/health', async (request, response) => {
-		try {
-			// Ping webservice to verify that the chain
-			// Dashboard > webservice > MongoDB is operational.
-			// eslint-disable-next-line n/no-unsupported-features/node-builtins
-			const result = await fetch(webserviceUrl, {
-				// CloudFoundry for example has a 1 second timeout for the health check
-				// The 750ms timeout aims to keep us within that window
-				signal: AbortSignal.timeout(750)
-			});
-			if (result.ok) {
-				return response.status(200).json({
-					status: 'ok'
-				});
-			}
-			response.status(503).json({
-				status: 'error',
-				message: 'webservice responded with an error'
-			});
-		} catch {
-			response.status(503).json({
-				status: 'error',
-				message: 'webservice unavailable'
-			});
-		}
+// Health check endpoint for liveness probes used by load balancers,
+// container orchestrators, and platform health monitors.
+module.exports = function health(app) {
+	app.express.get('/health', (request, response) => {
+		response.status(200).json({
+			status: 'ok'
+		});
 	});
 };


### PR DESCRIPTION
This removes the dependency on webservice and therefore MongoDB which might take too long to repond and cause health checks to fail.